### PR TITLE
disable catalog dropdown in lieu of config file

### DIFF
--- a/stac_ipyleaflet/stac_discovery/stac_widget.py
+++ b/stac_ipyleaflet/stac_discovery/stac_widget.py
@@ -66,10 +66,10 @@ class StacDiscoveryWidget:
             {"name": "MAAP STAC", "url": "https://stac.maap-project.org"},
             # {"name": "VEDA STAC", "url": "https://staging-stac.delta-backend.com"},
             # {"name": "MAAP STAC", "url": "https://wssn144yw1.execute-api.us-west-2.amazonaws.com/"},
-            {
-                "name": "Element84 Earth Search",
-                "url": "https://earth-search.aws.element84.com/v1",
-            },
+            # {
+            #     "name": "Element84 Earth Search",
+            #     "url": "https://earth-search.aws.element84.com/v1",
+            # },
             # {"name": "Microsoft Planetary Computer", "url": "https://planetarycomputer.microsoft.com/api/stac/v1"},
         ]
         # make list of name values from stac_catalogs
@@ -118,6 +118,7 @@ class StacDiscoveryWidget:
             value=self.stac_data["catalog"]["name"],
             style=styles["init"],
             layout=layouts["default"],
+            disabled=True,
         )
         catalogs_box = VBox(
             [


### PR DESCRIPTION
## Summary:
**What** did I do?
- I disabled the Catalog dropdown again
**Why** *** did I do it? (What was the motivation?)
- In lieu of upcoming option to load config file to instantiate the library
**How** *** can someone test or demo my changes?
- Load the stac_ipyleaflet map, open the STAC tool, and note that the Catalog dropdown is inaccessible



## Checklist before requesting a review:
- [ ] My code follows the guidelines of this project
- [ ] I  performed a self-review of my code changes
- [ ] I have added my changes to the change log (`HISTORY.rst`)
- [ ] I have completed spell-checking, removed unnecessary print statements & commented-out code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
