### PR TITLE
Update env vars to split stac_catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Once these have been installed, follow these steps below:
 ```
 TITILER_STAC_ENDPOINT=https://titiler-stac.maap-project.org
 TITILER_ENDPOINT=https://titiler.maap-project.org
-STAC_CATALOG={"name": "MAAP STAC", "url": "https://stac.maap-project.org"}
+STAC_CATALOG_NAME=MAAP STAC
+STAC_CATALOG_URL=https://stac.maap-project.org
 ```
 5. Run `jupyter lab` and this should reveal two links in the log, you would want to click and open any of those two!
 ![](/public/images/getting-started-links.png)

--- a/stac_ipyleaflet/constants.py
+++ b/stac_ipyleaflet/constants.py
@@ -8,6 +8,4 @@ REQUEST_TIMEOUT = 3  # three second timeout
 RESCALE = "0,50"
 TITILER_ENDPOINT = os.getenv("TITILER_ENDPOINT")
 TITILER_STAC_ENDPOINT = os.getenv("TITILER_STAC_ENDPOINT")
-STAC_CATALOG = (
-    json.loads(os.getenv("STAC_CATALOG")) if os.getenv("STAC_CATALOG") else None
-)
+STAC_CATALOG = {"name": os.getenv("STAC_CATALOG_NAME"), "url": os.getenv("STAC_CATALOG_URL")}

--- a/stac_ipyleaflet/core.py
+++ b/stac_ipyleaflet/core.py
@@ -83,9 +83,16 @@ class StacIpyleaflet(Map):
         if TITILER_ENDPOINT is None:
             missing.append("TITILER_ENDPOINT")
             warning_log += "os.environ['TITILER_ENDPOINT']='REPLACE_WITH_TITILER_URL'\n"
-        if STAC_CATALOG is None:
-            missing.append("STAC_CATALOG")
-            warning_log += "os.environ['STAC_CATALOG'] = {'name': 'REPLACE_WITH_STAC_CATALOG_NAME_FOR_LABEL_USE', 'url': 'REPLACE_WITH_STAC_CATALOG_URL'}\n"
+        if STAC_CATALOG["name"] is None:
+            missing.append("STAC_CATALOG_NAME")
+            warning_log += (
+                "os.environ['STAC_CATALOG_NAME']='REPLACE_WITH_NAME_OF_STAC_CATALOG'\n"
+            )
+        if STAC_CATALOG["url"] is None:
+            missing.append("STAC_CATALOG_URL")
+            warning_log += (
+                "os.environ['STAC_CATALOG_URL']='REPLACE_WITH_URL_OF_STAC_CATALOG'\n"
+            )
         if len(missing) > 0:
             logging.warning(
                 f"Following environment variable(s) are missing {missing} \n To set these environment variables, run this code: \n \n import os \n {warning_log}"


### PR DESCRIPTION
## Summary:
- **What** did I do?
Split `STAC_CATALOG` env var to now take `STAC_CATALOG_NAME` and `STAC_CATALOG_URL`
- **Why** *** did I do it? (What was the motivation?)
- **How** *** can someone test or demo my changes?
![Screenshot 2023-08-31 at 10 31 05 AM](https://github.com/MAAP-Project/stac_ipyleaflet/assets/30272083/12bb7233-2808-4f2f-84ee-3330f1cc60cc)
<img width="813" alt="Screenshot 2023-08-31 at 10 31 17 AM" src="https://github.com/MAAP-Project/stac_ipyleaflet/assets/30272083/881b66b7-bd03-4d84-9b05-b6764f6c92bf">

  _*** **When relevant, use screenshots to document**_


### Fixes or Addresses Issue \#: [ticket number & link]


## Checklist before requesting a review:
- [ ] My code follows the guidelines of this project
- [ ] I  performed a self-review of my code changes
- [ ] I have added my changes to the change log (`HISTORY.rst`)
- [ ] I have completed spell-checking, removed unnecessary print statements & commented-out code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
