### PR TITLE
Agnostic loading of BROWSER and CATALOG urls

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,3 +34,8 @@ History
 ----------------------
 
 * Bug fix to return collections even when non-compliant STAC collections and items exist
+
+dev
+----------------------
+
+* Bug fix, agnostic parsing of STAC_BROWSER_URL (Issue #116)

--- a/stac_ipyleaflet/stac_discovery/stac_widget.py
+++ b/stac_ipyleaflet/stac_discovery/stac_widget.py
@@ -196,15 +196,14 @@ class StacDiscoveryWidget:
                 layout=layouts["default"],
             )
 
-            # @TODO: We need to come here clean this up to make it more agnostic
-            if "maap" in STAC_BROWSER_URL:
-                stac_browser_url = self.stac_data["collection"]["href"].replace(
-                    "https://", STAC_BROWSER_URL
-                )
-            elif "veda" in STAC_BROWSER_URL:
+            # If STAC_BROWSER_URL does not exist or is not set, fallback to STAC URL
+            if STAC_BROWSER_URL is not None:
                 stac_browser_url = self.stac_data["collection"]["href"].replace(
                     STAC_CATALOG["url"], STAC_BROWSER_URL
                 )
+            else:
+                stac_browser_url = self.stac_data["collection"]["href"]
+                
             collection_url_browser = HTML(
                 value=f'<a href={stac_browser_url} target="_blank"><b>View in STAC Browser</b></a>',
                 style=styles["init"],


### PR DESCRIPTION
#116 
Always just sub BROWSER url for STAC url. Can better describe in docs what values are expected. See also https://github.com/MAAP-Project/stac_ipyleaflet/issues/116

## Summary:
Old code handled MAAP and VEDA STAC_BROWSER_URL differently, this assumed that the ENV variables were quite different. By standardizing how the ENV is supplied agnostic code can be used, and a fallback in the event of missing variable can also be handled.


### Fixes or Addresses Issue \#: [ticket number & link]
#116 

## Checklist before requesting a review:
- [x] My code follows the guidelines of this project
- [x] I  performed a self-review of my code changes
- [x] I have added my changes to the change log (`HISTORY.rst`)
- [x] I have completed spell-checking, removed unnecessary print statements & commented-out code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
